### PR TITLE
CI action의 Node 20 런타임 제거

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: "22"
 
@@ -156,8 +156,8 @@ runs:
         python3 "$GITHUB_ACTION_PATH/scripts/post_inline_comments.py" || echo "Warning: inline comments failed (non-fatal)"
 
     - name: Comments on PR
-      uses: peter-evans/create-or-update-comment@v3
+      uses: peter-evans/create-or-update-comment@v5
       with:
         token: ${{ inputs.github_token }}
         issue-number: ${{ github.event.pull_request.number }}
-        body-file: review.md
+        body-path: review.md


### PR DESCRIPTION
## 변경 사항
- `actions/setup-node`를 Node 24 기반 v7로 갱신합니다.
- PR 코멘트 action을 Node 24 기반 `peter-evans/create-or-update-comment@v5`로 갱신합니다.
- deprecated된 `body-file` 입력을 `body-path`로 전환합니다.

## 배경
`p2achAI/codex-reviewer@v2.0.0`을 사용하는 workflow에서 내부 action의 Node 20 deprecated 경고가 계속 발생했습니다. 호출부만 바꿔서는 없어지지 않아 upstream composite action을 수정합니다.

## 검증
- `git diff --check`
- `bash scripts/local_smoke_test.sh` (openai, claude, mock smoke 모두 통과)
- v5 `action.yml`의 런타임이 `node24`이고 `body-path`가 정식 입력임을 확인