### PR TITLE
Support repositories that require immutable action references

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         node-version: "22"
 
@@ -155,9 +155,9 @@ runs:
       run: |
         python3 "$GITHUB_ACTION_PATH/scripts/post_inline_comments.py" || echo "Warning: inline comments failed (non-fatal)"
 
-    - name: Comments on PR
-      uses: peter-evans/create-or-update-comment@v5
-      with:
-        token: ${{ inputs.github_token }}
-        issue-number: ${{ github.event.pull_request.number }}
-        body-path: review.md
+    - name: Comment on PR
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: python3 "$GITHUB_ACTION_PATH/scripts/post_review_comment.py"

--- a/scripts/local_smoke_test.sh
+++ b/scripts/local_smoke_test.sh
@@ -320,4 +320,8 @@ if [ "${MODE}" != "--live" ]; then
   echo "claude smoke test passed"
 fi
 
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
+  -s "${ROOT_DIR}/scripts" \
+  -p 'test_*.py'
+
 echo "local smoke test passed (mode=${MODE})"

--- a/scripts/post_review_comment.py
+++ b/scripts/post_review_comment.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Post the generated review as a pull request issue comment."""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def post_comment(api_url, repository, pr_number, body, token):
+    """Create a pull request issue comment through the GitHub REST API."""
+    url = f"{api_url}/repos/{repository}/issues/{pr_number}/comments"
+    data = json.dumps({"body": body}).encode("utf-8")
+    request = urllib.request.Request(url, data=data, method="POST")
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("Content-Type", "application/json")
+    request.add_header("X-GitHub-Api-Version", "2022-11-28")
+
+    with urllib.request.urlopen(request) as response:
+        return json.loads(response.read())
+
+
+def main():
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    pr_number = os.environ.get("PR_NUMBER", "")
+    api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    review_file = os.environ.get("REVIEW_FILE", "review.md")
+
+    if not token or not repository or not pr_number:
+        print(
+            "Missing required env vars (GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER)",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        with open(review_file, "r", encoding="utf-8") as review:
+            body = review.read()
+    except OSError as error:
+        print(f"Unable to read review file {review_file}: {error}", file=sys.stderr)
+        return 1
+
+    if not body.strip():
+        print(f"Review file {review_file} is empty", file=sys.stderr)
+        return 1
+
+    try:
+        result = post_comment(api_url, repository, pr_number, body, token)
+    except urllib.error.HTTPError as error:
+        error_body = error.read().decode("utf-8", errors="replace")
+        print(f"GitHub API error {error.code}: {error_body}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as error:
+        print(f"GitHub API request failed: {error.reason}", file=sys.stderr)
+        return 1
+
+    print(f"Review comment posted: {result.get('html_url', '')}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_post_review_comment.py
+++ b/scripts/test_post_review_comment.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import post_review_comment
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class PostReviewCommentTest(unittest.TestCase):
+    def test_post_comment_uses_pull_request_issue_comments_api(self):
+        response = FakeResponse({"html_url": "https://example.test/comment/1"})
+
+        with mock.patch("urllib.request.urlopen", return_value=response) as urlopen:
+            result = post_review_comment.post_comment(
+                "https://api.github.test",
+                "p2achAI/example",
+                "42",
+                "review body",
+                "secret-token",
+            )
+
+        request = urlopen.call_args.args[0]
+        self.assertEqual(
+            request.full_url,
+            "https://api.github.test/repos/p2achAI/example/issues/42/comments",
+        )
+        self.assertEqual(request.get_method(), "POST")
+        self.assertEqual(json.loads(request.data), {"body": "review body"})
+        self.assertEqual(request.get_header("Authorization"), "Bearer secret-token")
+        self.assertEqual(result["html_url"], "https://example.test/comment/1")
+
+    def test_main_posts_review_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as review:
+            review.write("## Review\n\nNo findings.")
+            review.flush()
+            env = {
+                "GITHUB_TOKEN": "secret-token",
+                "GITHUB_REPOSITORY": "p2achAI/example",
+                "PR_NUMBER": "42",
+                "REVIEW_FILE": review.name,
+            }
+            result = {"html_url": "https://example.test/comment/1"}
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                post_review_comment, "post_comment", return_value=result
+            ) as post:
+                self.assertEqual(post_review_comment.main(), 0)
+
+        post.assert_called_once_with(
+            "https://api.github.com",
+            "p2achAI/example",
+            "42",
+            "## Review\n\nNo findings.",
+            "secret-token",
+        )
+
+    def test_main_rejects_empty_review(self):
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as review:
+            review.write("  \n")
+            review.flush()
+            env = {
+                "GITHUB_TOKEN": "secret-token",
+                "GITHUB_REPOSITORY": "p2achAI/example",
+                "PR_NUMBER": "42",
+                "REVIEW_FILE": review.name,
+            }
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch(
+                "sys.stderr", new_callable=io.StringIO
+            ) as stderr:
+                self.assertEqual(post_review_comment.main(), 1)
+
+        self.assertIn("is empty", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- pin the official setup-node dependency to the full commit behind v7
- replace the disallowed third-party comment action with a direct GitHub REST API client
- cover review-comment posting in the existing local smoke test

## Why
Repositories with GitHub Actions SHA pinning enabled reject this composite action before execution because its nested actions used mutable tags, and one nested action came from a disallowed third-party owner.

## Verification
- PYTHONDONTWRITEBYTECODE=1 bash scripts/local_smoke_test.sh
- action.yml parses as YAML
- all nested action references are immutable