### PR TITLE
Add a centralized reusable review workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+self-hosted-runner:
+  labels:
+    - pro6000-cpu
+    - io-light
+    - io-heavy
+
+paths:
+  .github/workflows/review.yml:
+    ignore:
+      # GitHub.com exposes these for jobs defined by reusable workflows.
+      # actionlint 1.7.12 has not added them to its job context schema yet.
+      - 'property "workflow_(repository|sha)" is not defined'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,138 @@
+name: Reusable Codex Review
+
+on:
+  workflow_call:
+    inputs:
+      provider:
+        description: AI provider (claude or openai)
+        type: string
+        default: claude
+      model:
+        description: Model passed to the reviewer
+        type: string
+        default: claude-opus-4-6
+      effort:
+        description: Review effort level
+        type: string
+        default: high
+      language:
+        description: Review output language
+        type: string
+        default: korean
+      codex_version:
+        description: Pinned Codex CLI version
+        type: string
+        default: 0.115.0-alpha.27
+      claude_code_version:
+        description: Pinned Claude Code version
+        type: string
+        default: 2.1.150
+    secrets:
+      OPENAI_API_KEY:
+        required: false
+      ANTHROPIC_API_KEY:
+        required: false
+      CLICKUP_API_TOKEN:
+        required: false
+      CLICKUP_TEAM_ID:
+        required: false
+
+concurrency:
+  group: codex-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  codex_review:
+    name: codex_review
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'codex-review' ||
+      github.event.label.name == 'codex-review-perf' ||
+      github.event.label.name == 'codex-review-bug' ||
+      github.event.label.name == 'codex-review-high'
+    runs-on: [self-hosted, Linux, X64, io-light]
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Resolve review mode
+        id: resolve_mode
+        shell: bash
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          CURRENT_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          mode=""
+          if [ "$HEAD_REPOSITORY" != "$CURRENT_REPOSITORY" ]; then
+            echo "::warning::Fork PR에서는 self-hosted AI 리뷰를 실행하지 않음"
+          else
+            case "${EVENT_ACTION:-}" in
+              opened)
+                if [ "${IS_DRAFT:-true}" = "false" ]; then
+                  mode="spec"
+                fi
+                ;;
+              ready_for_review)
+                mode="spec"
+                ;;
+              labeled)
+                case "${LABEL_NAME:-}" in
+                  "codex-review") mode="spec" ;;
+                  "codex-review-perf") mode="perf" ;;
+                  "codex-review-bug") mode="bug" ;;
+                  "codex-review-high") mode="high" ;;
+                esac
+                ;;
+              synchronize|reopened)
+                # Keep a current successful check without generating another review.
+                ;;
+            esac
+          fi
+
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
+      - name: Check out pull request
+        if: steps.resolve_mode.outputs.mode != ''
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Check out reviewer implementation
+        if: steps.resolve_mode.outputs.mode != ''
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: .github-actions/codex-reviewer
+          persist-credentials: false
+
+      - name: Isolate global npm install path
+        if: steps.resolve_mode.outputs.mode != ''
+        shell: bash
+        run: |
+          npm_prefix="$RUNNER_TEMP/npm-global-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$GITHUB_JOB"
+          mkdir -p "$npm_prefix"
+          echo "NPM_CONFIG_PREFIX=$npm_prefix" >> "$GITHUB_ENV"
+          echo "$npm_prefix/bin" >> "$GITHUB_PATH"
+
+      - name: Run review
+        if: steps.resolve_mode.outputs.mode != ''
+        uses: ./.github-actions/codex-reviewer
+        with:
+          github_token: ${{ github.token }}
+          provider: ${{ inputs.provider }}
+          model: ${{ inputs.model }}
+          effort: ${{ inputs.effort }}
+          language: ${{ inputs.language }}
+          codex_version: ${{ inputs.codex_version }}
+          claude_code_version: ${{ inputs.claude_code_version }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          clickup_api_token: ${{ secrets.CLICKUP_API_TOKEN }}
+          clickup_team_id: ${{ secrets.CLICKUP_TEAM_ID }}

--- a/README.md
+++ b/README.md
@@ -17,43 +17,48 @@ An automated GitHub Action that reviews pull requests and provides AI-powered co
 
 ### Basic Setup
 
-Create a workflow file in your repository's `.github/workflows` directory:
+For organization repositories, call the reusable workflow. It centralizes the
+runner, permissions, trigger filtering, and composite action implementation:
 
 ```yaml
 name: Codex PR Review
 
 on:
   pull_request:
-    types: [labeled] # add synchronize if you want to trigger the action when the PR is synchronized
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
-  review:
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    runs-on: ubuntu-latest
-    if: github.event.label.name == 'codex-review'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - uses: p2achAI/codex-reviewer@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          label: 'codex-review'
-          provider: "claude"
-          model: "claude-opus-4-6"
-          effort: "high"
-          language: "korean"
-          custom_prompt: "Please review the code"
-          clickup_api_token: ${{ secrets.CLICKUP_API_TOKEN }}
-          clickup_url: "https://app.clickup.com/t/ABC-123"
-          clickup_team_id: "90144302619"
-          clickup_custom_task_ids: "true"
-          spec_comment_marker: "SPEC:"
+  codex_review:
+    uses: p2achAI/codex-reviewer/.github/workflows/review.yml@<release-commit-sha>
+    secrets: inherit
 ```
+
+Use the full commit SHA behind a release, not a mutable tag. Enable Dependabot
+for `github-actions` in each consumer repository so these immutable references
+are updated by reviewable pull requests instead of manual edits:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+```
+
+The reusable workflow automatically reviews non-draft PRs on `opened` and
+`ready_for_review`. The exact labels `codex-review`, `codex-review-perf`,
+`codex-review-bug`, and `codex-review-high` trigger explicit review modes.
+`synchronize` and `reopened` keep the check current without generating a new
+review. Fork pull requests never run on the self-hosted reviewer.
+
+Use the composite action directly only when a repository needs a custom runner
+or trigger policy. Direct consumers must pin this repository and every nested
+action to full commit SHAs.
 
 ### Input Parameters
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,19 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   codex_review:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: p2achAI/codex-reviewer/.github/workflows/review.yml@<release-commit-sha>
-    secrets: inherit
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLICKUP_API_TOKEN: ${{ secrets.CLICKUP_API_TOKEN }}
+      CLICKUP_TEAM_ID: ${{ secrets.CLICKUP_TEAM_ID }}
 ```
 
 Use the full commit SHA behind a release, not a mutable tag. Enable Dependabot


### PR DESCRIPTION
## Summary
- add a reusable pull-request review workflow with centralized triggers, runner assignment, permissions, and fork safeguards
- load the composite reviewer from the exact reusable-workflow commit via the GitHub job identity context
- pin all external actions to immutable SHAs and enable weekly GitHub Actions Dependabot updates
- document the thin consumer workflow and immutable update path

## Runner policy
- AI review and no-op status checks: self-hosted Linux X64 io-light
- pro6000-cpu and io-heavy are registered for lint validation but are not used by this I/O-light review workload

## Verification
- actionlint -config-file .github/actionlint.yaml .github/workflows/review.yml
- YAML parse for workflow, actionlint, and Dependabot configuration
- PYTHONDONTWRITEBYTECODE=1 bash scripts/local_smoke_test.sh
- immutable external action reference scan

## Follow-up
After this workflow is released, consumer repositories can replace the copied implementation with one SHA-pinned reusable-workflow call and let Dependabot propose future SHA updates.